### PR TITLE
Mongo scheduler uses rabbit host from connection string

### DIFF
--- a/Source/EasyNetQ.Scheduler.Mongo/SchedulerServiceConfiguration.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo/SchedulerServiceConfiguration.cs
@@ -10,11 +10,13 @@ namespace EasyNetQ.Scheduler.Mongo
         public TimeSpan PublishInterval { get; set; }
         public TimeSpan HandleTimeoutInterval { get; set; }
         public int PublishMaxSchedules { get; set; }
+        public string RabbitHost { get; set; }
 
         public static SchedulerServiceConfiguration FromConfigFile()
         {
             return new SchedulerServiceConfiguration
             {
+                RabbitHost = ConfigurationManager.ConnectionStrings["rabbit"].ConnectionString,
                 SubscriptionId = ConfigurationManager.AppSettings["subscriptionId"],
                 PublishInterval = GetTimeSpanAppSettings("publishInterval"),
                 PublishMaxSchedules = GetIntAppSetting("publishMaxSchedules"),

--- a/Source/EasyNetQ.Scheduler.Mongo/SchedulerServiceFactory.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo/SchedulerServiceFactory.cs
@@ -7,7 +7,7 @@ namespace EasyNetQ.Scheduler.Mongo
         public static ISchedulerService CreateScheduler()
         {
             var serviceConfig = SchedulerServiceConfiguration.FromConfigFile();
-            var bus = RabbitHutch.CreateBus("host=localhost", sr =>
+            var bus = RabbitHutch.CreateBus(serviceConfig.RabbitHost, sr =>
             {
                 if (serviceConfig.EnableLegacyConventions) sr.EnableLegacyConventions();
             });


### PR DESCRIPTION
Hi! I found out that mongo scheduler doesn't use rabbit connection string from app.config and uses hardcoded value instead. It seems like a bug for me so I suggest these changes.